### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,11 +34,11 @@ Community
 ----------
 
 Conjecture is very young and doesn't really have a community of its own, but
-discussion of it is extremely welcome in the `Hypothesis Community <http://hypothesis.readthedocs.org/en/latest/community.html>`_.
+discussion of it is extremely welcome in the `Hypothesis Community <https://hypothesis.readthedocs.io/en/latest/community.html>`_.
 
 In particular we have the IRC channel #hypothesis on Freenode.
 
-Please note that there is `a code of conduct <http://hypothesis.readthedocs.org/en/latest/community.html#code-of-conduct>`_
+Please note that there is `a code of conduct <https://hypothesis.readthedocs.io/en/latest/community.html#code-of-conduct>`_
 in effect in this community and you are expected to adhere to it.
 
 ------------------
@@ -46,7 +46,7 @@ Development Status
 ------------------
 
 Conjecture is currently a prototype. The python code base demonstrates that it works (extremely well in fact)
-but is not ready to use, and besides you should probaby be using `Hypothesis <http://hypothesis.readthedocs.org/en/latest/>`_ instead.
+but is not ready to use, and besides you should probaby be using `Hypothesis <https://hypothesis.readthedocs.io/en/latest/>`_ instead.
 
 If you're interested in having Conjecture available for your language, I am able and willing to do so for a very
 reasonable day rate: The design is one that is extremely easy to port to new languages, so in most cases it is

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -406,7 +406,7 @@ References
 * Property based testing in its modern incarnations almost all are derived from
   `Quickcheck <https://hackage.haskell.org/package/QuickCheck>`_.
 * Much of the work that Conjecture is built on comes from advances I made to the core ideas of Quickcheck in
-  `Hypothesis <http://hypothesis.readthedocs.org/en/latest/>`_.
+  `Hypothesis <https://hypothesis.readthedocs.io/en/latest/>`_.
 * This sort of inversion where you are given a function to call from your tests that controls the testing
   behaviour has been done before in `"eXplode:a Lightweight, General System for Finding Serious Storage
   System Errors" <http://web.stanford.edu/~engler/explode-osdi06.pdf>`_ by Junfeng Yang, Can Sar, and

--- a/python/README.rst
+++ b/python/README.rst
@@ -8,6 +8,6 @@ production ready software. In particular it lacks some of the practical but
 not very interesting features (example saving) and the provided strategies are
 somewhat low quality and half-baked.
 
-If you want this sort of testing in Python, may I recommend `Hypothesis <http://hypothesis.readthedocs.org/>`_?
+If you want this sort of testing in Python, may I recommend `Hypothesis <https://hypothesis.readthedocs.io/>`_?
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.